### PR TITLE
Escape username and database name

### DIFF
--- a/contrib/root/usr/share/scripts/patroni/post_init.sh
+++ b/contrib/root/usr/share/scripts/patroni/post_init.sh
@@ -3,10 +3,10 @@ set -Eeu
 
 if [[ (! -z "$APP_USER") &&  (! -z "$APP_PASSWORD") && (! -z "$APP_DATABASE")]]; then
   echo "Creating user ${APP_USER}"
-  psql "$1" -w -c "create user ${APP_USER} WITH LOGIN ENCRYPTED PASSWORD '${APP_PASSWORD}'"
+  psql "$1" -w -c "create user \"${APP_USER}\" WITH LOGIN ENCRYPTED PASSWORD '${APP_PASSWORD}'"
 
   echo "Creating database ${APP_DATABASE}"
-  psql "$1" -w -c "CREATE DATABASE ${APP_DATABASE} OWNER ${APP_USER} ENCODING '${APP_DB_ENCODING:-UTF8}' LC_COLLATE = '${APP_DB_LC_COLLATE:-en_US.UTF-8}' LC_CTYPE = '${APP_DB_LC_CTYPE:-en_US.UTF-8}'"
+  psql "$1" -w -c "CREATE DATABASE \"${APP_DATABASE}\" OWNER \"${APP_USER}\" ENCODING '${APP_DB_ENCODING:-UTF8}' LC_COLLATE = '${APP_DB_LC_COLLATE:-en_US.UTF-8}' LC_CTYPE = '${APP_DB_LC_CTYPE:-en_US.UTF-8}'"
 
 else
   echo "Skipping user creation"


### PR DESCRIPTION
Escape username and database name to allow for usernames and database names with dashes in them.

e.g. Currently "my-username" will cause a failure. This fix will allow it to work.