### PR TITLE
Handle changing root user password 

### DIFF
--- a/contrib/root/usr/share/scripts/patroni/post_init.sh
+++ b/contrib/root/usr/share/scripts/patroni/post_init.sh
@@ -2,8 +2,14 @@
 set -Eeu
 
 if [[ (! -z "$APP_USER") &&  (! -z "$APP_PASSWORD") && (! -z "$APP_DATABASE")]]; then
-  echo "Creating user ${APP_USER}"
-  psql "$1" -w -c "create user \"${APP_USER}\" WITH LOGIN ENCRYPTED PASSWORD '${APP_PASSWORD}'"
+
+  if [ "$APP_USER" = "postgres" ]; then
+    echo "Updating postgres user with new password $APP_PASSWORD"
+    psql "$1" -w -c "ALTER ROLE \"postgres\" WITH ENCRYPTED PASSWORD '${APP_PASSWORD}'"
+  else
+    echo "Creating user ${APP_USER}"
+    psql "$1" -w -c "create user \"${APP_USER}\" WITH LOGIN ENCRYPTED PASSWORD '${APP_PASSWORD}'"
+  fi
 
   echo "Creating database ${APP_DATABASE}"
   psql "$1" -w -c "CREATE DATABASE \"${APP_DATABASE}\" OWNER \"${APP_USER}\" ENCODING '${APP_DB_ENCODING:-UTF8}' LC_COLLATE = '${APP_DB_LC_COLLATE:-en_US.UTF-8}' LC_CTYPE = '${APP_DB_LC_CTYPE:-en_US.UTF-8}'"


### PR DESCRIPTION
## Summary

Some services (like aqua) connect to the default user 'postgres' but with a custom password. Although this behaviour can probably be changed I figured it be nice to handle updating the postgres user with a password. 


My bash skills aren't sharp. hope the if statement is correct!