### PR TITLE
changed version env to version arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM postgres:12.4
 
 LABEL Alexander Kukushkin <alexander.kukushkin@zalando.de>
 
-ENV PATRONI_VERSION=1.6.5
+ARG patroniv=1.6.5
+ENV PATRONI_VERSION=$patroniv
 ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 ENV PATRONI_HOME=/opt/patroni
 


### PR DESCRIPTION
A bug was discovered in version 1.6.5 of patroni which caused crashing. We do not wish to change the default version for those who use this dockerfile, as we do not wish to force an update to the version without their knowledge. However, we do wish to provide the ability for users to upgrade on their own to a patroni version >2 in order to get rid of the bug. This arg change allows users to specify a buildarg in their buildconfig in order to do so.