### PR TITLE
Added postgis support to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update -y \
     && apt-get install -y curl jq locales git build-essential libpq-dev python3 python3-dev python3-pip python3-wheel python3-setuptools python3-virtualenv python3-pystache python3-requests patchutils binutils \
     && apt-get install -y postgresql-common libevent-2.1 libevent-pthreads-2.1 brotli libbrotli1 python3.6 python3-psycopg2 \
+    && apt-get install -y postgresql-postgis postgresql-12-pgrouting postgresql-contrib postgresql-12-pg-qualstats \
     && echo 'Make sure we have a en_US.UTF-8 locale available' \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
     && pip3 --isolated --no-cache-dir install psycopg2-binary==2.8.6 six psutil \
@@ -37,7 +38,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* /root/.cache
-    
 
 COPY contrib/root /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* /root/.cache
 
+
 COPY contrib/root /
 
 VOLUME /home/postgres/pgdata


### PR DESCRIPTION
This installs the following additional support:

postgresql-postgis: support for geographic objects
postgresql-12-pgrouting: routing and other network analysis functionality to PostGIS
postgresql-contrib: advanced object-relational database management system that supports an extended subset of the SQL standard, including transactions, foreign keys, subqueries, triggers, and user-defined types and functions
postgresql-12-pg-qualstats: PostgreSQL extension keeping statistics on predicates found in WHERE statements and JOIN clauses. This is useful if you want to be able to analyze what are the most-often executed quals (predicates) on your database


These modules still need a "CREATE" in the runtime PSQL service which is an optional task for the consumer of this image.