### PR TITLE
Bump postgres to 12.19 and patroni to 2.1.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:12.4
+FROM postgres:12.19
 
 LABEL Alexander Kukushkin <alexander.kukushkin@zalando.de>
 
-ARG patroniv=1.6.5
-#ARG postgresv=12.4
+ARG patroniv=2.1.7
+#ARG postgresv=12.19
 ENV PATRONI_VERSION=$patroniv
 #ENV PGVERSION=$postgresv
 ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
@@ -17,11 +17,12 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && echo 'APT::Install-Recommends "0";\nAPT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01norecommend \
     && apt-get update -y \
     && apt-get install -y curl jq locales git build-essential libpq-dev python3 python3-dev python3-pip python3-wheel python3-setuptools python3-virtualenv python3-pystache python3-requests patchutils binutils \
-    && apt-get install -y postgresql-common libevent-2.1 libevent-pthreads-2.1 brotli libbrotli1 python3.6 python3-psycopg2 \
+    && apt-get install -y postgresql-common libevent-2.1 libevent-pthreads-2.1 brotli libbrotli1 python3-psycopg2 python3-yaml \
     && echo 'Make sure we have a en_US.UTF-8 locale available' \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
-    && pip3 --isolated --no-cache-dir install psycopg2-binary==2.8.6 six psutil \
-    && pip3 --isolated --no-cache-dir install "patroni[kubernetes]==${PATRONI_VERSION}" \
+    && pip3 --isolated --no-cache-dir install psycopg2-binary==2.9.9 six psutil --break-system-packages \
+    && pip3 --isolated --no-cache-dir install "patroni[kubernetes]==${PATRONI_VERSION}" --break-system-packages \
+    && pip3 --isolated --no-cache-dir install ydiff==1.2 cdiff --break-system-packages \
     && PGHOME=/home/postgres \
     && mkdir -p $PGHOME \
     && sed -i "s|/var/lib/postgresql.*|$PGHOME:/bin/bash|" /etc/passwd \

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ You will find a sample of how to deploy the image [here](./samples/README.md).
 
 # Image Management
 
-This image is based on PostgreSQL v12.4.  Due to this being an old version of both Patroni and Postgres, we no longer automatically rebuild it to pick up software updates, because the Dockerfile no longer builds, due to software version changes.  We are planning on providing updated information soon.
+This image is based on PostgreSQL v12.19.  Due to this being an old version of both Patroni and Postgres, we no longer automatically rebuild it to pick up software updates, because the Dockerfile no longer builds, due to software version changes.  We are planning on providing updated information soon.
 
 ## Tags
 
-The stable tag for this image is `2.0.1-12.4-latest`.
+The stable tag for this image is `2.1.7-12.19-latest`.
 
 See the [release notes](./RELEASE.md) for more information and any other unique tags. 
 
@@ -19,7 +19,7 @@ See the [release notes](./RELEASE.md) for more information and any other unique 
 Below is a sample of how you might reference this image from a `StatefulSet` deployment manifest. 
 
 ```yaml
-  image: artifacts.developer.gov.bc.ca/bcgov-docker-local/patroni-postgres:2.0.1-12.4-latest
+  image: artifacts.developer.gov.bc.ca/bcgov-docker-local/patroni-postgres:2.1.7-12.19-latest
 ```
 
 Find a sample StatefulSet deployment [here](./samples/README.md).
@@ -57,8 +57,8 @@ oc secrets add sa/builder secrets/bcgov-tools-klab --for=pull
 And finally, create an `imagestreamtag` to import the image to your cluster. Again, for the `-from-image` argument use the **external registry host name**.
 
 ```console
-oc create imagestreamtag patroni-postgresql:12.4-latest \
-  --from-image=image-registry.foo.bar.gov.bc.ca /bcgov-tools/patroni-postgresql:12.4-latest
+oc create imagestreamtag patroni-postgresql:12.19-latest \
+  --from-image=image-registry.foo.bar.gov.bc.ca /bcgov-tools/patroni-postgresql:12.19-latest
 ```
 
 Check to make sure it imported:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,7 @@
 
 artifacts.developer.gov.bc.ca/bcgov-docker-local/patroni-postgres
 
-| Tag               | Description                      |
-| :---------------: | :------------------------------- |
-| 2.0.1-12.4-latest | PostgreSQL v12.4 with Patroni v2 |
+| Tag                | Description                       |
+| :----------------: | :-------------------------------- |
+| 2.1.7-12.19-latest | PostgreSQL v12.19 with Patroni v2 |
 

--- a/openshift/templates/build.yaml
+++ b/openshift/templates/build.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: patroni
@@ -29,13 +29,13 @@ parameters:
     value: "patroni-postgres"
   - name: OUT_VERSION
     description: Ouput version
-    value: "12.4-latest"
+    value: "2.1.7-12.19-latest"
   - name: GIT_URI
     value: "https://github.com/bcgov/patroni-postgres-container.git"
   - name: GIT_REF
     value: "master"
   - name: PG_VERSION
-    value: "12.4"
+    value: "12.9"
 objects:
   # Postgres ImageStream is created if it doesn't already exist
   - apiVersion: image.openshift.io/v1
@@ -84,11 +84,9 @@ objects:
         type: Git
       strategy:
         dockerStrategy:
-          pullSecret:
-            name: dockerhub-creds 
           from:
             kind: DockerImage
-            name: postgres:12.4
+            name: postgres:12.19
         type: Docker
       triggers:
         - type: ConfigChange

--- a/samples/deploy.yaml
+++ b/samples/deploy.yaml
@@ -260,7 +260,7 @@ parameters:
     description: |
       The image tag used to specify which image you would like deployed.
       Don't use `latest`.
-    value: "12.4-latest"
+    value: "12.19-latest"
   - name: PVC_SIZE
     description: The size of the persistent volume to create.
     displayName: Persistent Volume Size


### PR DESCRIPTION
This PR bumps the Docker base image from 12.4 to 12.19 and bumps the Patroni version from 1.6.5 to 2.1.7.