### PR TITLE
feat: make openshift builds version-specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TL;DR
 
-This repo contains the Platform Service (PS) and community maintained version of PostgreSQL managed by Patroni for High Availability (HA).  The image is available from Artifactory.
+This repo contains the ~Platform Service (PS) and community~ CHEFS maintained version of PostgreSQL managed by Patroni for High Availability (HA).  The image is available from Artifactory.
 
 You will find a sample of how to deploy the image [here](./samples/README.md).
 

--- a/README.md
+++ b/README.md
@@ -1,34 +1,11 @@
-# TL;DR
-
-This repo contains the ~Platform Service (PS) and community~ CHEFS maintained version of PostgreSQL managed by Patroni for High Availability (HA).  ~The image is available from Artifactory~.
-
-You will find a sample of how to deploy the image [here](./samples/README.md).
-
-# Image Management
-
-This image is based on PostgreSQL v12.4.  Due to this being an old version of both Patroni and Postgres, we no longer automatically rebuild it to pick up software updates, because the Dockerfile no longer builds, due to software version changes.  We are planning on providing updated information soon.
-
-## Tags
-
-The stable tag for this image is `2.0.1-12.4-latest`.
-
-See the [release notes](./RELEASE.md) for more information and any other unique tags. 
-
-## Usage
-
-Below is a sample of how you might reference this image from a `StatefulSet` deployment manifest. 
-
-```yaml
-  image: artifacts.developer.gov.bc.ca/bcgov-docker-local/patroni-postgres:2.0.1-12.4-latest
-```
-
-Find a sample StatefulSet deployment [here](./samples/README.md).
+This repo contains the CHEFS-maintained version of PostgreSQL managed by Patroni for High Availability (HA).
 
 # Build
 
-This image is built as per the [workflow](.github/workflows/image.yaml) and the OpenShift [templates](./openshift/templates).
+This image is built as per the OpenShift [templates](./openshift).
 
 ## Distribution
+
 This is the old section that describes copying the image to your local namespace.
 
 Run RBAC to create an SA and bind it to, this is done on a lab or build cluster:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TL;DR
 
-This repo contains the ~Platform Service (PS) and community~ CHEFS maintained version of PostgreSQL managed by Patroni for High Availability (HA).  The image is available from Artifactory.
+This repo contains the ~Platform Service (PS) and community~ CHEFS maintained version of PostgreSQL managed by Patroni for High Availability (HA).  ~The image is available from Artifactory~.
 
 You will find a sample of how to deploy the image [here](./samples/README.md).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,0 @@
-
-## Release Notes and Tags
-
-artifacts.developer.gov.bc.ca/bcgov-docker-local/patroni-postgres
-
-| Tag               | Description                      |
-| :---------------: | :------------------------------- |
-| 2.0.1-12.4-latest | PostgreSQL v12.4 with Patroni v2 |
-

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,0 +1,21 @@
+
+# OpenShift Templates
+
+These templates are used to build the Patroni PostgreSQL containers.
+
+## Build
+
+The template will create a `BuildConfig` that is configured to use the given
+Patroni and PostgreSQL versions.
+
+```sh
+$ oc process -f build.yaml -p PATRONI_VERSION=1.6.5 -p PG_VERSION=12.4 |\
+    oc -n a12c97-tools apply -f -
+imagestream.image.openshift.io/postgres created
+imagestreamtag.image.openshift.io/postgres:12.4 created
+imagestream.image.openshift.io/patroni-postgres created
+buildconfig.build.openshift.io/patroni-postgres created
+```
+
+> Note that PostgreSQL 12 is not longer supported and was the legacy version
+> used in this repo.

--- a/openshift/templates/build.yaml
+++ b/openshift/templates/build.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: patroni
@@ -27,14 +27,15 @@ labels:
 parameters:
   - name: NAME
     value: "patroni-postgres"
-  - name: OUT_VERSION
-    description: Ouput version
-    value: "12.4-latest"
   - name: GIT_URI
-    value: "https://github.com/bcgov/patroni-postgres-container.git"
+    value: "https://github.com/bcgov/patroni-postgres-container-chefs.git"
   - name: GIT_REF
-    value: "master"
+    value: "main"
+  - name: PATRONI_VERSION
+    description: The version of Patroni to be used in the build
+    value: "1.6.5"
   - name: PG_VERSION
+    description: The version of PostgreSQL to be used in the build
     value: "12.4"
 objects:
   # Postgres ImageStream is created if it doesn't already exist
@@ -54,7 +55,7 @@ objects:
     tag:
       from:
         kind: DockerImage
-        name: registry.hub.docker.com/library/postgres:${PG_VERSION}
+        name: artifacts.developer.gov.bc.ca/docker-remote/library/postgres:${PG_VERSION}
       importPolicy:
         scheduled: true
       name: "${PG_VERSION}"
@@ -70,12 +71,12 @@ objects:
   - apiVersion: v1
     kind: BuildConfig
     metadata:
-      name: ${NAME}
+      name: ${NAME}-${PATRONI_VERSION}-${PG_VERSION}
     spec:
       output:
         to:
           kind: ImageStreamTag
-          name: "${NAME}:${OUT_VERSION}"
+          name: "${NAME}:${PATRONI_VERSION}-${PG_VERSION}-latest"
       source:
         contextDir: /
         git:
@@ -84,11 +85,14 @@ objects:
         type: Git
       strategy:
         dockerStrategy:
-          pullSecret:
-            name: dockerhub-creds 
+          buildArgs:
+            - name: "patroniv"
+              value: "${PATRONI_VERSION}"
+            - name: "postgresv"
+              value: "${PG_VERSION}"
           from:
             kind: DockerImage
-            name: postgres:12.4
+            name: postgres:${PG_VERSION}
         type: Docker
       triggers:
         - type: ConfigChange


### PR DESCRIPTION
Replace the hard-coded PostgreSQL version with something that can be defined when creating the BuildConfig. Do likewise with the Patroni version. This means that each BuildConfig will be specific to a Patroni version and PostgreSQL version combo.